### PR TITLE
match default tabs to notebook implementation

### DIFF
--- a/scoped-properties/langugage-ipynb.cson
+++ b/scoped-properties/langugage-ipynb.cson
@@ -3,3 +3,4 @@
     'foldEndPattern': '(?x:        # turn on extended mode\n\t                        ^        # a line beginning with\n\t                        \\s*      # some optional space\n\t                        [}\\]]    # and the close of an object or array\n\t                      )'
     'increaseIndentPattern': '^.*(\\{[^}]*|\\[[^\\]]*)$'
     'decreaseIndentPattern': '^\\s*[}\\]],?\\s*$'
+    'tabLength': 1


### PR DESCRIPTION
In the notebook default, it stores .ipynb files with 1 space per tab, this sets it as such or language-ipynb